### PR TITLE
Formatting fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,5 +74,10 @@
             <artifactId>jbcrypt</artifactId>
             <version>0.3m</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/me/urielsalis/mojiraFeedIRC/Feed.java
+++ b/src/main/java/me/urielsalis/mojiraFeedIRC/Feed.java
@@ -13,7 +13,7 @@ public class Feed {
     String author;
 
     public Feed(SyndEntryImpl entry) {
-        this.link = entry.getLink();
+        this.link = entry.getLink().replace("&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel", ""); // shorten comment links
         this.title = entry.getTitle().replaceAll("\\<[^>]*>", "").trim().substring(entry.getAuthor().length()+1).replaceAll(" +", " ");; //remove all html tags and extra spaces
         this.author = entry.getAuthor().replaceAll("\\[[^\\]]*", "").trim();
     }

--- a/src/main/java/me/urielsalis/mojiraFeedIRC/Feed.java
+++ b/src/main/java/me/urielsalis/mojiraFeedIRC/Feed.java
@@ -15,7 +15,7 @@ public class Feed {
     public Feed(SyndEntryImpl entry) {
         this.link = entry.getLink().replace("&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel", ""); // shorten comment links
         this.title = entry.getTitle().replaceAll("\\<[^>]*>", "").trim().substring(entry.getAuthor().length()+1).replaceAll("\\s+", " "); //remove all html tags and extra spaces/new lines
-        this.author = entry.getAuthor().replaceAll("\\[[^\\]]*", "").trim();
+        this.author = entry.getAuthor().replaceAll("\\[[^\\]]*", "").trim().replaceAll(" ", "_"); // remove [Mod] prefixes; don't include spaces in usernames
     }
 
     @Override

--- a/src/main/java/me/urielsalis/mojiraFeedIRC/Feed.java
+++ b/src/main/java/me/urielsalis/mojiraFeedIRC/Feed.java
@@ -16,7 +16,7 @@ public class Feed {
     public Feed(SyndEntryImpl entry) {
         this.link = entry.getLink().replace("&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel", ""); // shorten comment links
         this.title = StringEscapeUtils.unescapeHtml4(entry.getTitle().replaceAll("\\<[^>]*>", "").trim().substring(entry.getAuthor().length()+1).replaceAll("\\s+", " ")); //remove all html tags and extra spaces/new lines; unescape HTML entities
-        this.author = entry.getAuthor().replaceAll("\\[[^\\]]*", "").trim().replaceAll(" ", "_"); // remove [Mod] prefixes; don't include spaces in usernames
+        this.author = entry.getAuthor().replaceAll("\\[.*?\\]", "").trim().replaceAll(" ", "_"); // remove [Mod] prefixes; don't include spaces in usernames
     }
 
     @Override

--- a/src/main/java/me/urielsalis/mojiraFeedIRC/Feed.java
+++ b/src/main/java/me/urielsalis/mojiraFeedIRC/Feed.java
@@ -1,6 +1,7 @@
 package me.urielsalis.mojiraFeedIRC;
 
 import com.sun.syndication.feed.synd.SyndEntryImpl;
+import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * mojirafeed
@@ -14,7 +15,7 @@ public class Feed {
 
     public Feed(SyndEntryImpl entry) {
         this.link = entry.getLink().replace("&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel", ""); // shorten comment links
-        this.title = entry.getTitle().replaceAll("\\<[^>]*>", "").trim().substring(entry.getAuthor().length()+1).replaceAll("\\s+", " "); //remove all html tags and extra spaces/new lines
+        this.title = StringEscapeUtils.unescapeHtml4(entry.getTitle().replaceAll("\\<[^>]*>", "").trim().substring(entry.getAuthor().length()+1).replaceAll("\\s+", " ")); //remove all html tags and extra spaces/new lines; unescape HTML entities
         this.author = entry.getAuthor().replaceAll("\\[[^\\]]*", "").trim().replaceAll(" ", "_"); // remove [Mod] prefixes; don't include spaces in usernames
     }
 

--- a/src/main/java/me/urielsalis/mojiraFeedIRC/Feed.java
+++ b/src/main/java/me/urielsalis/mojiraFeedIRC/Feed.java
@@ -14,7 +14,7 @@ public class Feed {
 
     public Feed(SyndEntryImpl entry) {
         this.link = entry.getLink().replace("&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel", ""); // shorten comment links
-        this.title = entry.getTitle().replaceAll("\\<[^>]*>", "").trim().substring(entry.getAuthor().length()+1).replaceAll(" +", " ");; //remove all html tags and extra spaces
+        this.title = entry.getTitle().replaceAll("\\<[^>]*>", "").trim().substring(entry.getAuthor().length()+1).replaceAll("\\s+", " "); //remove all html tags and extra spaces/new lines
         this.author = entry.getAuthor().replaceAll("\\[[^\\]]*", "").trim();
     }
 


### PR DESCRIPTION
*  f54f621: Convenience.  Before the links would be very long, such as this:  
    https://bugs.mojang.com/browse/REALMS-364?focusedCommentId=398511&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-398511  
    Now links are much shorter, such as this:
    https://bugs.mojang.com/browse/REALMS-364?focusedCommentId=398511#comment-398511  
    This has the problem of not automatically going to the comments tab if you weren't on it, but in the majority of cases you already are there, and it makes the link _so much shorter_ (short enough to fit in one line without very annoying word wrapping) that I think it's worthwhile.

*  95c4e5a: Previously when an issue was resolved, things would fail due to a new line splitting the text sent:
    ```
    15:55:43     mojira =!= | irc: command "as" not found:
    15:55:43     mojira =!= | as 'Cannot Reproduce'
    ```
    Now the newlines are replaced with spaces, allowing that text to work correctly.

* 7e78d01: Previously spaces in usernames would break things:
    ```
    15:55:20     mojira =!= | irc: command "Gatens" not found:
    15:55:20     mojira =!= | :Rory Gatens PRIVMSG #feed : 07 https://bugs.mojang.com/browse/MCCE-3881  - resolved MCCE-3881 - enchant shovel promblems
    ```
    Spaces are now replaced with underscores, fixing that.  (I don't know if this is the perfect solution, but I'm not sure exactly what is/isn't allowed there).
