### PR TITLE
Limit author names to 20 characters

### DIFF
--- a/src/main/java/me/urielsalis/mojiraFeedIRC/Feed.java
+++ b/src/main/java/me/urielsalis/mojiraFeedIRC/Feed.java
@@ -2,6 +2,7 @@ package me.urielsalis.mojiraFeedIRC;
 
 import com.sun.syndication.feed.synd.SyndEntryImpl;
 import org.apache.commons.text.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * mojirafeed
@@ -16,7 +17,7 @@ public class Feed {
     public Feed(SyndEntryImpl entry) {
         this.link = entry.getLink().replace("&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel", ""); // shorten comment links
         this.title = StringEscapeUtils.unescapeHtml4(entry.getTitle().replaceAll("\\<[^>]*>", "").trim().substring(entry.getAuthor().length()+1).replaceAll("\\s+", " ")); //remove all html tags and extra spaces/new lines; unescape HTML entities
-        this.author = entry.getAuthor().replaceAll("\\[.*?\\]", "").trim().replaceAll(" ", "_"); // remove [Mod] prefixes; don't include spaces in usernames
+        this.author = StringUtils.abbreviate(entry.getAuthor().replaceAll("\\[.*?\\]", "").trim().replaceAll(" ", "_"), 20); // remove [Mod] prefixes; don't include spaces in usernames; make sure the length is no more than 20
     }
 
     @Override


### PR DESCRIPTION
This helps prevent things like [this](https://user-images.githubusercontent.com/8334194/29244915-cb1addbc-7f7b-11e7-8e15-ae2a63a00725.png) from happening.
